### PR TITLE
ci(codeql): exclude examples directory from security scanning (#24)

### DIFF
--- a/.github/codeql-config.yml
+++ b/.github/codeql-config.yml
@@ -1,0 +1,4 @@
+name: 'CodeQL Config'
+
+paths-ignore:
+    - examples

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,6 +30,7 @@ jobs:
               uses: github/codeql-action/init@v3
               with:
                   languages: ${{ matrix.language }}
+                  config-file: ./.github/codeql-config.yml
 
             - name: Autobuild
               uses: github/codeql-action/autobuild@v3


### PR DESCRIPTION
## Summary
This PR configures CodeQL to ignore the `/examples` directory during security scanning. This directory contains test files with intentional syntax errors and incomplete code constructs (used for testing extension features) that were causing false positives and build failures in the security pipeline.

## Changes
- **Added Config**: Created `.github/codeql-config.yml` with a `paths-ignore` rule for the `examples` folder.
- **Updated Workflow**: Modified `.github/workflows/codeql.yml` to use this custom configuration file.
