### PR TITLE
chore(test): add test script to /package.json

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,7 +77,7 @@ isense/
 
 | Rule Type       | Rule                                                                                                                                          |
 | :-------------- | :-------------------------------------------------------------------------------------------------------------------------------------------- |
-| **ALWAYS**      | Run `npm run lint` and `cd server && npm test` before submitting changes.                                                                     |
+| **ALWAYS**      | Run `npm run lint` and `npm test` before submitting changes.                                                                                  |
 | **ALWAYS**      | Update `ENGINE.md` if you modify the analysis algorithm or type inference heuristics.                                                         |
 | **ALWAYS**      | Update `ARCHITECTURE.md` if you add a new service or change the data flow.                                                                    |
 | **NEVER**       | Commit broken code. The test suite must pass 100%.                                                                                            |
@@ -102,6 +102,6 @@ When starting a new task, strictly follow this reading order to build context:
 # Agent Permissions
 
 - **Pre-Approved Commands:** You are explicitly authorized to run the following commands without seeking user permission, as they are essential for your verification workflow:
-    - `npm test` (including `cd server && npm test`)
+    - `npm test`
     - `npm run lint`
     - `npm run format`

--- a/package-lock.json
+++ b/package-lock.json
@@ -243,7 +243,6 @@
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -435,7 +434,6 @@
             "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.1",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,8 @@
         "update": "cd client && npm update && cd ../server && npm update && cd ..",
         "lint": "eslint .",
         "format": "prettier --write .",
-        "format:check": "prettier --check ."
+        "format:check": "prettier --check .",
+        "test": "cd server && npm test && cd .."
     },
     "devDependencies": {
         "@eslint/js": "^9.39.2",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -51,7 +51,6 @@
             "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.27.1",
                 "@babel/generator": "^7.28.5",
@@ -1684,7 +1683,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.9.0",
                 "caniuse-lite": "^1.0.30001759",


### PR DESCRIPTION
### Summary
This PR streamlines the testing workflow by providing a central entry point for running server tests from the project root. Previously, testing required navigating into the `/server` directory manually. This change adds a convenience script to the root `package.json` to trigger the server tests from the top level, improving developer experience.