### PR TITLE
chore(engines): sync vscode engine with modern types and lsp dependencies (#63)

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -10,7 +10,7 @@
         "url": "https://github.com/ntoulasm/isense"
     },
     "engines": {
-        "vscode": "^1.108.0"
+        "vscode": "^1.109.0"
     },
     "dependencies": {
         "vscode-languageclient": "^9.0.1"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
         "JavaScript"
     ],
     "engines": {
-        "vscode": "^1.108.0",
+        "vscode": "^1.109.0",
         "node": "24.13.1"
     },
     "activationEvents": [


### PR DESCRIPTION
### Summary
This PR bumps `engines.vscode` in root and `/client` `package.json` from 1.52.0 to 1.109.0